### PR TITLE
Support configurable processor for post-processing of maintenance mes…

### DIFF
--- a/lib/rack/maintenance.rb
+++ b/lib/rack/maintenance.rb
@@ -13,7 +13,8 @@ class Rack::Maintenance
 
   def call(env)
     if maintenance? && path_in_app(env)
-      data = File.read(file)
+      content = File.read(file)
+      data = processor.call(content)
       [ 503, { 'Content-Type' => content_type, 'Content-Length' => data.bytesize.to_s }, [data] ]
     else
       app.call(env)
@@ -32,6 +33,10 @@ private ######################################################################
 
   def file
     options[:file]
+  end
+
+  def processor
+    options[:processor] || lambda { |content| content }
   end
 
   def maintenance?

--- a/spec/rack-maintenance_spec.rb
+++ b/spec/rack-maintenance_spec.rb
@@ -66,6 +66,18 @@ shared_examples "RackMaintenance" do
           app.should_not_receive :call
           rack.call({})
         end
+
+        context "and :processor option" do
+          let(:processor) { lambda { |content| ERB.new(content).result } }
+          let(:rack) do
+            Rack::Maintenance.new(app, :file => file_name, :processor => processor )
+          end
+
+          it "passes the file content to the processor" do
+            processor.should_receive(:call).with(data).and_call_original
+            rack.call({})
+          end
+        end
       end
     end
 


### PR DESCRIPTION
The purpose of this PR is to allow the user to provide post-processing of the maintenance file.  The intended use is to support a template processor like ERB to be used to merge content into the maintenance page.  This would allow the value of the ```ENV``` variable to be a string of descriptive text clarifying the maintenance session (e.g., service outage, expected down time, etc).